### PR TITLE
Add missing dependency

### DIFF
--- a/slime-help.el
+++ b/slime-help.el
@@ -32,6 +32,7 @@
 (require 'button)
 (require 'lisp-mode)
 (require 'slime)
+(require 'subr-x)
 
 (defface slime-help-heading-1
   '((t :weight bold


### PR DESCRIPTION
This fixes `upcase: Symbol’s function definition is void: string-trim` error, which might happen in `slime-help-package` if nobody's loaded `subr-x` yet 